### PR TITLE
feat: Better api

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,25 +11,30 @@ a simple cli tool for bumping semantic versions in various config file formats.
 ## usage
 
 ```sh
-svbump [LEVEL] [SELECTOR] [FILE] # bumping
-svbump read [SELECTOR] [FILE]    # reading
+svbump write [LEVEL] [SELECTOR] [FILE]   # modify version
+svbump read [SELECTOR] [FILE]            # read version
+svbump preview [LEVEL] [SELECTOR] [FILE] # preview change
 ```
+
 ### examples
 
 ```sh
 # bump the patch version in package.json
-svbump patch version package.json
+svbump write patch version package.json
 
 # bump the minor version in a nested field
-svbump minor package.version Cargo.toml
+svbump write minor package.version Cargo.toml
 
 # bump the major version in a yaml file
-svbump major version app.yaml
+svbump write major version app.yaml
 
 # set a specific version (must be higher than current)
-svbump 2.5.0 version package.json
+svbump write 2.5.0 version package.json
 
-# print the current version to stdout without modifying
+# preview what a bump would do without modifying
+svbump preview minor version package.json
+
+# print the current version to stdout
 svbump read version package.json
 svbump read package.version Cargo.toml
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,12 +279,12 @@ mod tests {
         fs::write(&temp_file, json_content)?;
 
         let args = Args {
-            command: None,
-            level: Some(VersionBump::Patch),
-            selector: Some("version".to_string()),
-            file: Some(temp_file.path().to_path_buf()),
+            command: Command::Write {
+                level: VersionBump::Patch,
+                selector: "version".to_string(),
+                file: temp_file.path().to_path_buf(),
+            },
             file_type: None,
-            preview: false,
         };
 
         let content = fs::read_to_string(temp_file.path())?;
@@ -311,12 +311,12 @@ version = "1.2.3"
         fs::write(&temp_file, toml_content)?;
 
         let args = Args {
-            command: None,
-            level: Some(VersionBump::Minor),
-            selector: Some("package.version".to_string()),
-            file: Some(temp_file.path().to_path_buf()),
+            command: Command::Write {
+                level: VersionBump::Minor,
+                selector: "package.version".to_string(),
+                file: temp_file.path().to_path_buf(),
+            },
             file_type: None,
-            preview: false,
         };
 
         let content = fs::read_to_string(temp_file.path())?;
@@ -343,32 +343,29 @@ version = "1.2.3"
 
         // Test setting a valid higher version
         let args = Args {
-            command: None,
-            level: Some(VersionBump::Specific(Version::new(2, 5, 0))),
-            selector: Some("version".to_string()),
-            file: Some(temp_file.path().to_path_buf()),
+            command: Command::Write {
+                level: VersionBump::Specific(Version::new(2, 5, 0)),
+                selector: "version".to_string(),
+                file: temp_file.path().to_path_buf(),
+            },
             file_type: None,
-            preview: false,
         };
 
         let content = fs::read_to_string(temp_file.path())?;
         let mut value: JsonValue = serde_json::from_str(&content)?;
         bump_version_json(
             &mut value,
-            args.selector.as_ref().unwrap(),
-            args.level.as_ref().unwrap(),
+            "version",
+            &VersionBump::Specific(Version::new(2, 5, 0)),
         )?;
         assert_eq!(value["version"], "2.5.0");
 
         // Test that setting a lower version fails
-        let args_lower = Args {
-            command: None,
-            level: Some(VersionBump::Specific(Version::new(1, 0, 0))),
-            selector: Some("version".to_string()),
-            file: Some(temp_file.path().to_path_buf()),
-            file_type: None,
-            preview: false,
-        };
+        let result = bump_version_json(
+            &mut value,
+            "version",
+            &VersionBump::Specific(Version::new(1, 0, 0)),
+        );
 
         let result = bump_version_json(
             &mut value,
@@ -390,12 +387,12 @@ version: 1.2.3
         fs::write(&temp_file, yaml_content)?;
 
         let args = Args {
-            command: None,
-            level: Some(VersionBump::Major),
-            selector: Some("version".to_string()),
-            file: Some(temp_file.path().to_path_buf()),
+            command: Command::Write {
+                level: VersionBump::Major,
+                selector: "version".to_string(),
+                file: temp_file.path().to_path_buf(),
+            },
             file_type: None,
-            preview: false,
         };
 
         let content = fs::read_to_string(temp_file.path())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,11 +289,9 @@ mod tests {
 
         let content = fs::read_to_string(temp_file.path())?;
         let mut value: JsonValue = serde_json::from_str(&content)?;
-        bump_version_json(
-            &mut value,
-            args.selector.as_ref().unwrap(),
-            args.level.as_ref().unwrap(),
-        )?;
+        if let Command::Write { level, selector, .. } = &args.command {
+            bump_version_json(&mut value, &selector, level)?;
+        }
 
         assert_eq!(value["version"], "1.2.4");
         Ok(())
@@ -321,11 +319,9 @@ version = "1.2.3"
 
         let content = fs::read_to_string(temp_file.path())?;
         let mut doc = content.parse::<DocumentMut>()?;
-        bump_version_toml(
-            &mut doc,
-            args.selector.as_ref().unwrap(),
-            args.level.as_ref().unwrap(),
-        )?;
+        if let Command::Write { level, selector, .. } = &args.command {
+            bump_version_toml(&mut doc, &selector, level)?;
+        }
 
         assert_eq!(doc["package"]["version"].as_str().unwrap(), "1.3.0");
         Ok(())
@@ -367,11 +363,6 @@ version = "1.2.3"
             &VersionBump::Specific(Version::new(1, 0, 0)),
         );
 
-        let result = bump_version_json(
-            &mut value,
-            args_lower.selector.as_ref().unwrap(),
-            args_lower.level.as_ref().unwrap(),
-        );
         assert!(result.is_err());
         Ok(())
     }
@@ -397,11 +388,9 @@ version: 1.2.3
 
         let content = fs::read_to_string(temp_file.path())?;
         let mut value: YamlValue = serde_yaml::from_str(&content)?;
-        bump_version_yaml(
-            &mut value,
-            args.selector.as_ref().unwrap(),
-            args.level.as_ref().unwrap(),
-        )?;
+        if let Command::Write { level, selector, .. } = &args.command {
+            bump_version_yaml(&mut value, &selector, level)?;
+        }
 
         assert_eq!(value["version"].as_str().unwrap(), "2.0.0");
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,22 +130,21 @@ fn main() -> Result<()> {
         Command::Write { level, selector, file } => {
             let path = file.as_path();
             let content = fs::read_to_string(path)?;
-                match get_file_type(path, args.file_type)? {
-                    "toml" => {
-                        let mut doc = content.parse::<DocumentMut>()?;
-                        bump_version_toml(&mut doc, &selector, &level)?;
-                        fs::write(path, doc.to_string())?;
-                    }
-                    "yml" | "yaml" => {
-                        let mut value: YamlValue = serde_yaml::from_str(&content)?;
-                        bump_version_yaml(&mut value, &selector, &level)?;
-                        fs::write(path, serde_yaml::to_string(&value)?)?;
-                    }
-                    _ => {
-                        let mut value: JsonValue = serde_json::from_str(&content)?;
-                        bump_version_json(&mut value, &selector, &level)?;
-                        fs::write(path, format!("{}\n", serde_json::to_string_pretty(&value)?))?;
-                    }
+            match get_file_type(path, args.file_type)? {
+                "toml" => {
+                    let mut doc = content.parse::<DocumentMut>()?;
+                    bump_version_toml(&mut doc, &selector, &level)?;
+                    fs::write(path, doc.to_string())?;
+                }
+                "yml" | "yaml" => {
+                    let mut value: YamlValue = serde_yaml::from_str(&content)?;
+                    bump_version_yaml(&mut value, &selector, &level)?;
+                    fs::write(path, serde_yaml::to_string(&value)?)?;
+                }
+                _ => {
+                    let mut value: JsonValue = serde_json::from_str(&content)?;
+                    bump_version_json(&mut value, &selector, &level)?;
+                    fs::write(path, format!("{}\n", serde_json::to_string_pretty(&value)?))?;
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,16 +337,6 @@ version = "1.2.3"
         let temp_file = NamedTempFile::new()?;
         fs::write(&temp_file, json_content)?;
 
-        // Test setting a valid higher version
-        let args = Args {
-            command: Command::Write {
-                level: VersionBump::Specific(Version::new(2, 5, 0)),
-                selector: "version".to_string(),
-                file: temp_file.path().to_path_buf(),
-            },
-            file_type: None,
-        };
-
         let content = fs::read_to_string(temp_file.path())?;
         let mut value: JsonValue = serde_json::from_str(&content)?;
         bump_version_json(


### PR DESCRIPTION
- **aider: refactor: Simplify version bumping with new `write` subcommand**
- **aider: feat: Add 'preview' subcommand to preview version bump without changes**
- **aider: fix: Resolve indentation and brace issues in main function**
- **aider: fix: Update test cases to match new CLI subcommand structure**
- **aider: fix: Update test cases to use Command enum fields correctly**
- **aider: fix: Remove unused `args` variable in test**
- **aider: docs: Update README with new svbump command syntax and subcommands**
